### PR TITLE
Stopped Chromium from crashing on Linux

### DIFF
--- a/lib/scrape.js
+++ b/lib/scrape.js
@@ -48,7 +48,7 @@ const query = (info, origin, encses, data) => {
 const Scraper = (url) =>
   (sId, pass) => {
 
-    let loginInfo, secretCode, gradebook, browser
+    let loginInfo, secretCode, gradebook, browser, args
 
     const referer = url.split('/')
       .slice(0, -1)
@@ -72,7 +72,10 @@ const Scraper = (url) =>
       }
     }
 
-    puppeteer.launch({ headless: true })
+    if(process.platform  === 'linux')
+      args = ['--no-sandbox']
+    
+    puppeteer.launch({ headless: true, args: args})
       .then(chrome => browser = chrome.on('targetcreated', handlePopup))
       .then(chrome => chrome.newPage())
       .then(page => page.goto(url)


### PR DESCRIPTION
SUID sandboxing is no longer needed on Linux, but it still checks for it.
* Check if platform is Linux, and add an argument to disable sandboxing

See: https://bugs.chromium.org/p/chromium/issues/detail?id=598454